### PR TITLE
Fix compatibility with version 5 of svelte-router

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Svelte & Firebase - A free template to create single page applications.</title>
+    <meta
+      name="description"
+      content="A free template that will help you create single page applications using amazing technologies like Svelte, Firebase, Bulma, Routing, Fontawesome and many others..."
+    />
+    <meta name="author" content="Jorge Alvarez" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="/global.css" />
+    <link rel="stylesheet" href="/stylesheets/custom.css" />
+    <link rel="stylesheet" href="/bundle.css" />
+    <link rel="stylesheet" href="/plugins.css" />
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+      .not-found {
+        margin: 3rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <section class="not-found">
+      <h1 class="title">Page not found!</h1>
+      <h3 class="subtitle">I've searched everywhere but it wasn't there. I'm as puzzled as you are!</h3>
+      <h5>
+        Return to the
+        <a href="/">homepage</a>
+      </h5>
+    </section>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="/plugins.css" />
   </head>
 
-  <body">
+  <body>
     <script src="/bundle.js"></script>
   </body>
 </html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Router } from 'svelte-router-spa'
-  import {routes } from './routes.js'
+  import { routes } from './routes.js'
   import '../node_modules/materialize-css/dist/css/materialize.min.css'
   import '../node_modules/materialize-css/dist/js/materialize.min.js'
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,8 @@
 <script>
   import { Router } from 'svelte-router-spa'
+  import {routes } from './routes.js'
   import '../node_modules/materialize-css/dist/css/materialize.min.css'
   import '../node_modules/materialize-css/dist/js/materialize.min.js'
 </script>
 
-<Router />
+<Router {routes } />

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,5 @@
 import App from './App.svelte'
-import { SpaRouter } from 'svelte-router-spa'
-import { routes } from './routes'
-import NotFound from './views/404.svelte'
 import './middleware/users/auth'
-
-SpaRouter({
-  routes,
-  pathName: document.location.href,
-  notFound: NotFound
-}).getActiveRoute
 
 const app = new App({
   target: document.body


### PR DESCRIPTION
Fixes #5 

It seems the recent package upgrade changed how 404's are handled in svelte-router. 

This adds a 404.html in public that looks like the 404 NotFound component.