### PR TITLE
removed firebase config file to prevent error on firebase init

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "svelte-firebase-template"
-  }
-}


### PR DESCRIPTION
.firebaserc has a predefined project name. If `firebase init` is executed, an error occurs because it requires a project with the same name to exist in user's Firebase console. Instead, remove this file and allow user to assign a different project